### PR TITLE
Potential fix for code scanning alert no. 22: Double escaping or unescaping

### DIFF
--- a/src/utils/sanitization.ts
+++ b/src/utils/sanitization.ts
@@ -64,7 +64,7 @@ export const sanitizeText = (input: string) => {
     .replace(/<[^>]*>/g, '')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
-    .replace(/&#x27;/g, "'");
+    .replace(/&#x27;/g, "'")
+    .replace(/&amp;/g, '&');
 };


### PR DESCRIPTION
Potential fix for [https://github.com/dataopsgroup/dataopsgroup/security/code-scanning/22](https://github.com/dataopsgroup/dataopsgroup/security/code-scanning/22)

To fix the issue, the replacements in the `sanitizeText` function should be reordered so that `&amp;` is replaced last. This ensures that other entities like `&lt;` and `&quot;` are decoded correctly before the ampersand itself is decoded. This approach aligns with the recommendation provided in the background section.

The changes will be made in the `sanitizeText` function in the file `src/utils/sanitization.ts`. Specifically:
1. Reorder the `.replace` calls so that `&amp;` is replaced after all other entities.
2. Ensure no other functionality is altered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
